### PR TITLE
Update CacheFactory.php

### DIFF
--- a/Cache/CacheFactory.php
+++ b/Cache/CacheFactory.php
@@ -17,6 +17,10 @@ class CacheFactory
      */
     public static function createByName($serviceName, ContainerInterface $container)
     {
+        if (null === $serviceName) {
+            return null;
+        }
+        
         $service = $container->get($serviceName, ContainerInterface::NULL_ON_INVALID_REFERENCE);
         return is_null($service) ? null : self::create($service);
     }


### PR DESCRIPTION
Actually, if `lexxpavlov_settings.cache_provider` is null it blow up with this error:
`Argument 1 passed to Symfony\Component\DependencyInjection\Container::make() must be of the type string, null given, called in /var/www/html/vendor/symfony/dependency-injection/Container.php on line 231`

This commit fix this by checking if we have a service name before attempting to register it.